### PR TITLE
Replace ostestr with stestr in testing framework.

### DIFF
--- a/cinder-{{cookiecutter.driver_name_lc}}/tox.ini
+++ b/cinder-{{cookiecutter.driver_name_lc}}/tox.ini
@@ -35,17 +35,17 @@ commands = true
 [testenv:py34]
 basepython = python3.4
 deps = -r{toxinidir}/test-requirements.txt
-commands = ostestr {posargs}
+commands = stestr run {posargs}
 
 [testenv:py35]
 basepython = python3.5
 deps = -r{toxinidir}/test-requirements.txt
-commands = ostestr {posargs}
+commands = stestr run {posargs}
 
 [testenv:py36]
 basepython = python3.6
 deps = -r{toxinidir}/test-requirements.txt
-commands = ostestr {posargs}
+commands = stestr run {posargs}
 
 [testenv:pep8]
 basepython = python3


### PR DESCRIPTION
A system upgrade broke ostestr. We can fix it by just calling stestr
directly.