### PR TITLE
Fix template to avoid lint errors.

### DIFF
--- a/cinder-{{cookiecutter.driver_name_lc}}/src/lib/charm/openstack/cinder_{{cookiecutter.driver_name_lc}}.py
+++ b/cinder-{{cookiecutter.driver_name_lc}}/src/lib/charm/openstack/cinder_{{cookiecutter.driver_name_lc}}.py
@@ -1,7 +1,8 @@
 import charms_openstack.charm
-import charmhelpers.core.hookenv as ch_hookenv # noqa 
+import charmhelpers.core.hookenv as ch_hookenv  # noqa
 
 charms_openstack.charm.use_defaults('charm.default-select-release')
+
 
 class Cinder{{ cookiecutter.driver_name }}Charm(
         charms_openstack.charm.CinderStoragePluginCharm):
@@ -21,6 +22,7 @@ class Cinder{{ cookiecutter.driver_name }}Charm(
             # Add config options that needs setting on cinder.conf
         ]
         return driver_options
+
 
 class Cinder{{ cookiecutter.driver_name }}CharmRocky(Cinder{{ cookiecutter.driver_name }}Charm):
 

--- a/cinder-{{cookiecutter.driver_name_lc}}/src/reactive/cinder_{{cookiecutter.driver_name_lc}}_handlers.py
+++ b/cinder-{{cookiecutter.driver_name_lc}}/src/reactive/cinder_{{cookiecutter.driver_name_lc}}_handlers.py
@@ -26,6 +26,7 @@ charms_openstack.charm.use_defaults(
     'storage-backend.connected',
 )
 
+
 @charms.reactive.when('config.changed.driver-source')
 def reinstall():
     with charms_openstack.charm.provide_charm_instance() as charm:

--- a/cinder-{{cookiecutter.driver_name_lc}}/src/tests/tests_cinder_{{cookiecutter.driver_name_lc}}.py
+++ b/cinder-{{cookiecutter.driver_name_lc}}/src/tests/tests_cinder_{{cookiecutter.driver_name_lc}}.py
@@ -23,6 +23,7 @@ import zaza.model
 import zaza.charm_tests.test_utils as test_utils
 import zaza.utilities.openstack as openstack_utils
 
+
 class Cinder{{ cookiecutter.driver_name }}Test(test_utils.OpenStackBaseTest):
     """Encapsulate {{ cookiecutter.driver_name }} tests."""
 
@@ -54,17 +55,16 @@ class Cinder{{ cookiecutter.driver_name }}Test(test_utils.OpenStackBaseTest):
             timeout=2)
 
     def test_create_volume(self):
-         test_vol_name = "zaza{}".format(uuid.uuid1().fields[0])
-         vol_new = self.cinder_client.volumes.create(
-             name=test_vol_name,
-             size=2)
-         openstack_utils.resource_reaches_status(
-             self.cinder_client.volumes,
-             vol_new.id,
-             expected_status='available')
-         test_vol = self.cinder_client.volumes.find(name=test_vol_name)
-         self.assertEqual(
-             getattr(test_vol, 'os-vol-host-attr:host').split('#')[0],
-             'cinder@cinder-{{ cookiecutter.driver_name_lc }}')
-         self.cinder_client.volumes.delete(vol_new)
-
+        test_vol_name = "zaza{}".format(uuid.uuid1().fields[0])
+        vol_new = self.cinder_client.volumes.create(
+            name=test_vol_name,
+            size=2)
+        openstack_utils.resource_reaches_status(
+            self.cinder_client.volumes,
+            vol_new.id,
+            expected_status='available')
+        test_vol = self.cinder_client.volumes.find(name=test_vol_name)
+        self.assertEqual(
+            getattr(test_vol, 'os-vol-host-attr:host').split('#')[0],
+            'cinder@cinder-{{ cookiecutter.driver_name_lc }}')
+        self.cinder_client.volumes.delete(vol_new)

--- a/cinder-{{cookiecutter.driver_name_lc}}/unit_tests/test_lib_charm_openstack_cinder_{{cookiecutter.driver_name_lc}}.py
+++ b/cinder-{{cookiecutter.driver_name_lc}}/unit_tests/test_lib_charm_openstack_cinder_{{cookiecutter.driver_name_lc}}.py
@@ -44,6 +44,6 @@ class TestCinder{{ cookiecutter.driver_name }}Charm(test_utils.PatchHelper):
 
     def test_cinder_configuration(self):
         charm = self._patch_config_and_charm({'a': 'b'})
-        config = charm.cinder_configuration() # noqa
+        config = charm.cinder_configuration()  # noqa
         # Add check here that configuration is as expected.
         # self.assertEqual(config, {})


### PR DESCRIPTION
The template is generating lint errors as follows:

pep8 runtests: commands[0] | flake8 src unit_tests
src/reactive/cinder_freenas_handlers.py:29:1: E302 expected 2 blank lines, found 1
src/reactive/cinder_freenas_handlers.py:31:61: F811 redefinition of unused 'charm' from line 20
src/tests/tests_cinder_freenas.py:26:1: E302 expected 2 blank lines, found 1
src/tests/tests_cinder_freenas.py:57:10: E111 indentation is not a multiple of four
src/tests/tests_cinder_freenas.py:57:10: E117 over-indented
src/tests/tests_cinder_freenas.py:58:10: E111 indentation is not a multiple of four
src/tests/tests_cinder_freenas.py:61:10: E111 indentation is not a multiple of four
src/tests/tests_cinder_freenas.py:65:10: E111 indentation is not a multiple of four
src/tests/tests_cinder_freenas.py:66:10: E111 indentation is not a multiple of four
src/tests/tests_cinder_freenas.py:69:10: E111 indentation is not a multiple of four
src/tests/tests_cinder_freenas.py:70:1: W391 blank line at end of file
src/lib/charm/openstack/cinder_freenas.py:6:1: E302 expected 2 blank lines, found 1
.
.
.
src/lib/charm/openstack/cinder_freenas.py:27:14: W191 indentation contains tabs
src/lib/charm/openstack/cinder_freenas.py:27:14: E101 indentation contains mixed spaces and tabs

This change should fix this.