### PR TITLE
Trivial Fix for Lint Error

### DIFF
--- a/cinder-{{cookiecutter.driver_name_lc}}/src/reactive/cinder_{{cookiecutter.driver_name_lc}}_handlers.py
+++ b/cinder-{{cookiecutter.driver_name_lc}}/src/reactive/cinder_{{cookiecutter.driver_name_lc}}_handlers.py
@@ -16,8 +16,10 @@ import charms_openstack.charm
 import charms.reactive
 
 # This charm's library contains all of the handler code associated with
-# this charm -- we need to import it to get the definitions for the charm.
-import charm.openstack.cinder_{{ cookiecutter.driver_name_lc }}  # noqa
+# this charm -- we will use the auto-discovery feature of charms.openstack
+# to get the definitions for the charm.
+import charms_openstack.bus
+charms_openstack.bus.discover()
 
 charms_openstack.charm.use_defaults(
     'charm.installed',


### PR DESCRIPTION
Fixes Error: "F811 redefinition of unused 'charm'" experienced
when running lint tests.

Instead of importing "charm.openstack.cinder_{{ ...}}" it is now using the auto-discovery feature of charms.openstack, as suggested by ajkavanagh. The comment is updated to reflect this.

Pep8, unit and functional tests are passing.