### PR TITLE
Wheelhouse.txt missing for python dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ cookiecutter https://github.com/openstack-charmers/cinder-storage-backend-templa
 3) Update 'cinder\_configuration' in src/lib/charm/openstack/cinder_*
 --------------------------------------------------------------------
 
-The 'cinderr\_configuration' method controls configuration options are sent to
+The 'cinder\_configuration' method controls configuration options are sent to
 the principle cinder charm for inclusion in cinder.conf. For example:
 
 If a 'superarray' driver was being configured in step 3 and

--- a/cinder-{{cookiecutter.driver_name_lc}}/requirements.txt
+++ b/cinder-{{cookiecutter.driver_name_lc}}/requirements.txt
@@ -1,5 +1,5 @@
 # This file is managed centrally.  If you find the need to modify this as a
-# one-off, please don't.  Intead, consult #openstack-charms and ask about
+# one-off, please don't.  Instead, consult #openstack-charms and ask about
 # requirements management in charms via bot-control.  Thank you.
 #
 # Build requirements

--- a/cinder-{{cookiecutter.driver_name_lc}}/src/test-requirements.txt
+++ b/cinder-{{cookiecutter.driver_name_lc}}/src/test-requirements.txt
@@ -1,9 +1,3 @@
 # zaza
-charm-tools>=2.4.4
-coverage>=3.6
-mock>=1.2
-flake8>=2.2.4,<=2.4.1
-stestr>=2.2.0
-requests>=2.18.4
 git+https://github.com/openstack-charmers/zaza.git#egg=zaza
 git+https://github.com/openstack-charmers/zaza-openstack-tests.git#egg=zaza.openstack

--- a/cinder-{{cookiecutter.driver_name_lc}}/src/test-requirements.txt
+++ b/cinder-{{cookiecutter.driver_name_lc}}/src/test-requirements.txt
@@ -1,2 +1,9 @@
 # zaza
+charm-tools>=2.4.4
+coverage>=3.6
+mock>=1.2
+flake8>=2.2.4,<=2.4.1
+stestr>=2.2.0
+requests>=2.18.4
 git+https://github.com/openstack-charmers/zaza.git#egg=zaza
+git+https://github.com/openstack-charmers/zaza-openstack-tests.git#egg=zaza.openstack

--- a/cinder-{{cookiecutter.driver_name_lc}}/src/tests/tests.yaml
+++ b/cinder-{{cookiecutter.driver_name_lc}}/src/tests/tests.yaml
@@ -2,7 +2,7 @@ charm_name: cinder-{{ cookiecutter.driver_name_lc }}
 tests:
   - tests.tests_cinder_{{ cookiecutter.driver_name_lc }}.Cinder{{ cookiecutter.driver_name }}Test
 configure:
-  - zaza.charm_tests.keystone.setup.add_demo_user
+  - zaza.openstack.charm_tests.keystone.setup.add_demo_user
 gate_bundles:
   - xenial-{{ cookiecutter.release }}
 smoke_bundles:

--- a/cinder-{{cookiecutter.driver_name_lc}}/wheelhouse.txt
+++ b/cinder-{{cookiecutter.driver_name_lc}}/wheelhouse.txt
@@ -1,0 +1,2 @@
+#layer-basic uses wheelhouse to install python dependencies
+psutil


### PR DESCRIPTION
Wheelhouse has been introduced in layer-basic to install python dependencies. It is needed to install the package psutil, needed in charmhelpers. 