### PR TITLE
Bug fixes for zaza and testbuild env

### DIFF
--- a/cinder-{{cookiecutter.driver_name_lc}}/src/layer.yaml
+++ b/cinder-{{cookiecutter.driver_name_lc}}/src/layer.yaml
@@ -9,3 +9,4 @@ config:
 options:
   basic:
     use_venv: True
+repo: https://github.com/openstack-charmers/cinder-storage-backend-template

--- a/cinder-{{cookiecutter.driver_name_lc}}/src/layer.yaml
+++ b/cinder-{{cookiecutter.driver_name_lc}}/src/layer.yaml
@@ -6,3 +6,6 @@ config:
       - use-syslog
       - use-internal-endpoints
       - ssl_ca
+options:
+  basic:
+    use_venv: True

--- a/cinder-{{cookiecutter.driver_name_lc}}/src/tests/tests_cinder_{{cookiecutter.driver_name_lc}}.py
+++ b/cinder-{{cookiecutter.driver_name_lc}}/src/tests/tests_cinder_{{cookiecutter.driver_name_lc}}.py
@@ -21,7 +21,7 @@ import uuid
 
 import zaza.model
 import zaza.openstack.charm_tests.test_utils as test_utils
-import zaza.utilities.openstack as openstack_utils
+import zaza.openstack.utilities.openstack as openstack_utils
 
 
 class Cinder{{ cookiecutter.driver_name }}Test(test_utils.OpenStackBaseTest):

--- a/cinder-{{cookiecutter.driver_name_lc}}/tox.ini
+++ b/cinder-{{cookiecutter.driver_name_lc}}/tox.ini
@@ -20,7 +20,7 @@ deps =
     -r{toxinidir}/requirements.txt
 
 [testenv:build]
-basepython = python2.7
+basepython = python3
 commands =
     charm-build --log-level DEBUG -o {toxinidir}/build src {posargs}
 


### PR DESCRIPTION
- basic options were missing from layer.yaml
- repo url added
- zaza broken path fixed
- testenv build should run on python3