### PR TITLE
Mask ssl_* options

### DIFF
--- a/cinder-{{cookiecutter.driver_name_lc}}/src/layer.yaml
+++ b/cinder-{{cookiecutter.driver_name_lc}}/src/layer.yaml
@@ -6,6 +6,8 @@ config:
       - use-syslog
       - use-internal-endpoints
       - ssl_ca
+      - ssl_cert
+      - ssl_key
 options:
   basic:
     use_venv: True


### PR DESCRIPTION
It doesn't make sense to include those two since the charm will be
subordinate and there will be no service to use TLS certs.