### PR TITLE
 set release_pkg

### DIFF
--- a/cinder-{{cookiecutter.driver_name_lc}}/src/lib/charm/openstack/cinder_{{cookiecutter.driver_name_lc}}.py
+++ b/cinder-{{cookiecutter.driver_name_lc}}/src/lib/charm/openstack/cinder_{{cookiecutter.driver_name_lc}}.py
@@ -11,6 +11,7 @@ class Cinder{{ cookiecutter.driver_name }}Charm(
     version_package = '{{ cookiecutter.package_name }}'
     release = '{{ cookiecutter.release }}'
     packages = [version_package]
+    release_pkg = version_package
     stateless = True
     # Specify any config that the user *must* set.
     mandatory_config = []


### PR DESCRIPTION
charms.openstack introduced release_pkg a while back, all reactive charm should set release_pkg, otherwise, hook install would fail