### PR TITLE
Add built charm to gitignore

### DIFF
--- a/cinder-{{cookiecutter.driver_name_lc}}/.gitignore
+++ b/cinder-{{cookiecutter.driver_name_lc}}/.gitignore
@@ -6,3 +6,4 @@ interfaces
 .stestr
 *__pycache__*
 *.pyc
+/*.charm


### PR DESCRIPTION
`tox -e build` produces a *.charm file that we don't
want to commit.